### PR TITLE
Fixes invitations

### DIFF
--- a/app/Repositories/TeamRepository.php
+++ b/app/Repositories/TeamRepository.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Spark\Repositories;
 
+use Laravel\Spark\Spark;
 use Laravel\Spark\Contracts\Repositories\TeamRepository as Contract;
 
 class TeamRepository implements Contract
@@ -89,7 +90,7 @@ class TeamRepository implements Contract
 
         $inviteModel = get_class((new $userModel)->invitations()->getQuery()->getModel());
 
-        $invitation = (new $inviteModel)->where('token', $invitation)->first();
+        $invitation = (new $inviteModel)->where('token', $invitationId)->first();
 
         if ($invitation) {
             $invitation->team->users()->attach([$user->id], ['role' => Spark::defaultRole()]);

--- a/app/Teams/Invitation.php
+++ b/app/Teams/Invitation.php
@@ -27,7 +27,7 @@ class Invitation extends Model
      *
      * @var array
      */
-    protected $hidden = ['token'];
+    protected $hidden = [];
 
     /**
      * Get the team that owns the invitation.


### PR DESCRIPTION
Javascript expects a token field to be received on the invitation object on the registration views. Unhide the token field from the model and fix syntax errors in the method to attach a user to a team.