### PR TITLE
fix: #32 Creating a team updates 'Current Teams' with lots of empty rows

### DIFF
--- a/resources/assets/js/settings/dashboard/teams.js
+++ b/resources/assets/js/settings/dashboard/teams.js
@@ -64,6 +64,7 @@ Vue.component('spark-settings-teams-screen', {
 
             this.createTeamForm.errors = [];
             this.createTeamForm.creating = true;
+            this.$http.options.emulateJSON = true;
 
             this.$http.post('/settings/teams', this.createTeamForm)
                 .success(function (teams) {


### PR DESCRIPTION
This fixes #32 by setting the emulateJSON option 

Which send request data as application/x-www-form-urlencoded content type

https://github.com/vuejs/vue-resource#options