### PR TITLE
Fixed callCustomValidator and $validateRegistrationsWith closure calls

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Auth;
 use Laravel\Spark\Subscriptions\Plan;
 use Laravel\Spark\Events\User\Registered;
 use Laravel\Spark\Events\User\Subscribed;
+use Laravel\Spark\InteractsWithSparkHooks;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Auth\ThrottlesLogins;
 use Illuminate\Foundation\Validation\ValidatesRequests;
@@ -25,7 +26,7 @@ use Laravel\Spark\Contracts\Auth\Subscriber as SubscriberContract;
 
 class AuthController extends Controller
 {
-    use AuthenticatesAndRegistersUsers, ThrottlesLogins, ValidatesRequests;
+    use AuthenticatesAndRegistersUsers, ThrottlesLogins, ValidatesRequests, InteractsWithSparkHooks;
 
     /**
      * The user repository instance.
@@ -226,9 +227,9 @@ class AuthController extends Controller
      */
     protected function validateRegistration(Request $request, $withSubscription = false)
     {
-        if (Spark::$validateProfileUpdatesWith) {
+        if (Spark::$validateRegistrationsWith) {
             $this->callCustomValidator(
-                Spark::$validateProfileUpdatesWith, $request, [$withSubscription]
+                Spark::$validateRegistrationsWith, $request, [$withSubscription]
             );
         } else {
             $this->validateDefaultRegistration($request, $withSubscription);

--- a/app/InteractsWithSparkHooks.php
+++ b/app/InteractsWithSparkHooks.php
@@ -24,7 +24,7 @@ trait InteractsWithSparkHooks
             $callback = [app($class), $method];
         }
 
-        $validator = call_user_func($callback, array_merge([$request], $arguments));
+        $validator = call_user_func_array($callback, array_merge([$request], $arguments));
 
         $validator = $validator instanceof ValidatorContract
                         ? $validator


### PR DESCRIPTION
* The callCustomValidator method wasn't using `call_user_func_array`
* The AuthController was looking for the wrong custom registration validator 
* The AuthController had no `InteractsWithSparkHooks` trait