### PR TITLE
Allow usage of a "createSubscriptionsWith" callback

### DIFF
--- a/app/Contracts/Repositories/UserRepository.php
+++ b/app/Contracts/Repositories/UserRepository.php
@@ -27,7 +27,7 @@ interface UserRepository
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @param  \Stripe\Customer  $stripeCustomer
+     * @param  \Stripe\Customer|null  $stripeCustomer
      * @return void
      */
     public function createSubscriptionOnStripe(Request $request, $user, $stripeCustomer = null);

--- a/app/Contracts/Repositories/UserRepository.php
+++ b/app/Contracts/Repositories/UserRepository.php
@@ -21,4 +21,14 @@ interface UserRepository
      * @return \Illuminate\Contracts\Auth\Authenticatable
      */
     public function createUserFromRegistrationRequest(Request $request, $withSubscription = false);
+
+    /**
+     * Create the subscription on Stripe.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Stripe\Customer  $stripeCustomer
+     * @return void
+     */
+    public function createSubscriptionOnStripe(Request $request, $user, $stripeCustomer = null);
 }

--- a/app/Http/Controllers/Settings/SubscriptionController.php
+++ b/app/Http/Controllers/Settings/SubscriptionController.php
@@ -52,16 +52,10 @@ class SubscriptionController extends Controller
     {
         $this->validateSubscription($request);
 
-        $plan = Spark::plans()->find($request->plan);
-
         $stripeCustomer = Auth::user()->stripe_id
                 ? Auth::user()->subscription()->getStripeCustomer() : null;
 
-        Auth::user()->subscription($request->plan)
-                ->skipTrial()
-                ->create($request->stripe_token, [
-                    'email' => Auth::user()->email,
-                ], $stripeCustomer);
+        $this->users->createSubscriptionOnStripe($request, Auth::user(), $stripeCustomer);
 
         event(new Subscribed(Auth::user()));
 

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -87,7 +87,7 @@ class UserRepository implements Contract
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @param  \Stripe\Customer  $stripeCustomer
+     * @param  \Stripe\Customer|null  $stripeCustomer
      * @return void
      */
     public function createSubscriptionOnStripe(Request $request, $user, $stripeCustomer = null)
@@ -118,7 +118,7 @@ class UserRepository implements Contract
      * @param Request $request
      * @param $user
      * @param $subscription
-     * @param  \Stripe\Customer  $stripeCustomer
+     * @param  \Stripe\Customer|null  $stripeCustomer
      */
     protected function createDefaultSubscription(Request $request, $user, $subscription, $stripeCustomer = null)
     {

--- a/app/Spark.php
+++ b/app/Spark.php
@@ -68,6 +68,13 @@ class Spark
     public static $createUsersWith;
 
     /**
+     * The callback used to create new subscriptions.
+     *
+     * @var callable|null
+     */
+    public static $createSubscriptionsWith;
+
+    /**
      * The callback used to move a user to another plan.
      *
      * @var callable|null
@@ -371,6 +378,17 @@ class Spark
     public static function createUsersWith($callback)
     {
         static::$createUsersWith = $callback;
+    }
+
+    /**
+     * Set a callback to be used to create new user subscriptions.
+     *
+     * @param  callable|string  $callback
+     * @return void
+     */
+    public static function createSubscriptionsWith($callback)
+    {
+        static::$createSubscriptionsWith = $callback;
     }
 
     /**


### PR DESCRIPTION
I added a `createSubscriptionsWith` callback to Stripe.
This allows to modify the Stripe customer creation - for example if you want to pass additional Stripe metadata.

This also removes the duplicate subscription creation within the `SubscriptionController`.