### PR TITLE
Custom callback for subscription swapping

### DIFF
--- a/app/Http/Controllers/Settings/SubscriptionController.php
+++ b/app/Http/Controllers/Settings/SubscriptionController.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Spark\Events\User\Subscribed;
 use Illuminate\Support\Facades\Validator;
+use Laravel\Spark\InteractsWithSparkHooks;
 use Illuminate\View\Expression as ViewExpression;
 use Laravel\Spark\Events\User\SubscriptionResumed;
 use Laravel\Spark\Events\User\SubscriptionCancelled;
@@ -19,7 +20,7 @@ use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 
 class SubscriptionController extends Controller
 {
-	use ValidatesRequests;
+	use InteractsWithSparkHooks, ValidatesRequests;
 
     /**
      * The user repository instance.
@@ -87,6 +88,8 @@ class SubscriptionController extends Controller
 
         if ($plan->price() === 0) {
             $this->cancelSubscription();
+        } elseif (Spark::$swapSubscriptionsWith) {
+            $this->callCustomUpdater(Spark::$swapSubscriptionsWith, $request, [Auth::user()]);
         } else {
             Auth::user()->subscription($request->plan)
                     ->maintainTrial()->prorate()->swapAndInvoice();

--- a/app/Spark.php
+++ b/app/Spark.php
@@ -60,6 +60,13 @@ class Spark
     public static $createUsersWith;
 
     /**
+     * The callback used to move a user to another plan.
+     *
+     * @var callable|null
+     */
+    public static $swapSubscriptionsWith;
+
+    /**
      * Indicates if two-factor authentication is supported.
      *
      * @var bool
@@ -345,6 +352,17 @@ class Spark
     public static function createUsersWith($callback)
     {
         static::$createUsersWith = $callback;
+    }
+
+    /**
+     * Set a callback to be used when moving the user to another plan.
+     *
+     * @param  callable|string  $callback
+     * @return void
+     */
+    public static function swapSubscriptionsWith($callback)
+    {
+        static::$swapSubscriptionsWith = $callback;
     }
 
     /**


### PR DESCRIPTION
This introduces a new `Spark::$swapSubscriptionsWith` callback that can be used when a user switches their plan, rather than Cashier’s built-in.