### PR TITLE
set `team->owner_id` as nullable.

### DIFF
--- a/resources/stubs/database/migrations/2014_10_12_200000_create_teams_tables.php
+++ b/resources/stubs/database/migrations/2014_10_12_200000_create_teams_tables.php
@@ -15,7 +15,7 @@ class CreateTeamsTables extends Migration
         // Create Teams Table...
         Schema::create('teams', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('owner_id')->index();
+            $table->integer('owner_id')->index()->nullable();
             $table->string('name');
             $table->timestamps();
         });


### PR DESCRIPTION
fixes an Integrity constraint violation when trying to add/create a team. (This may only affect sqlite? I don't think so though)