### PR TITLE
Make footer min-height

### DIFF
--- a/resources/assets/sass/spark.scss
+++ b/resources/assets/sass/spark.scss
@@ -37,7 +37,7 @@ body {
 	background-color: #f5f5f5;
 	border-top: 1px solid #e7e7e7;
 	bottom: 0;
-	height: 80px;
+	min-height: 80px;
 	position: absolute;
 	width: 100%;
 


### PR DESCRIPTION
The footer height wasn’t extending to bottom of page responsively. When viewing page responsively it was leaving a white background below the social icons. I have updated the footer to include a min-height of 80px, rather than height.

Here's what it was doing:
<img width="402" alt="screen shot 2015-09-21 at 12 36 31 am" src="https://cloud.githubusercontent.com/assets/5347897/9985378/040abd12-5ff9-11e5-845d-00a0da73b429.png">