### PR TITLE
Create encryption key during Spark install

### DIFF
--- a/app/Console/Install.php
+++ b/app/Console/Install.php
@@ -42,6 +42,7 @@ class Install extends Command
         $this->installSass();
         $this->installEnvironmentVariables();
         $this->installTerms();
+        $this->call('key:generate');
 
         $this->table(
             ['Task', 'Status'],


### PR DESCRIPTION
As the `config\app.php` file is overwritten during the Spark install, the key will need to be re-generated. Is this usually done for people when running `laravel new {project}`.