### PR TITLE
Ensure Sparkl remains referenced as a PHP project on Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,9 @@
 * text=auto
 
+*.js linguist-vendored
+*.scss linguist-vendored
+
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .php_cs export-ignore
-


### PR DESCRIPTION
Ensure Sparkl remains referenced as a PHP project on Github