### PR TITLE
Fix invitations for existing users

### DIFF
--- a/app/Teams/CanJoinTeams.php
+++ b/app/Teams/CanJoinTeams.php
@@ -34,7 +34,7 @@ trait CanJoinTeams
      */
     public function joinTeamById($teamId)
     {
-        $this->teams()->attach([$teamId]);
+        $this->teams()->attach([$teamId], ['role' => Spark::defaultRole()]);
 
         $this->currentTeam();
     }


### PR DESCRIPTION
When an existing user is invited, the role column on the pivot tabel remained empty, thus making the "Settings - Membership" page fail to render (because the Vue role filter complained about not being able to find the .text property of undefined). This fix properly sets the default role.