### PR TITLE
fix-everythingIsLoaded-membership

### DIFF
--- a/resources/assets/js/settings/team/membership.js
+++ b/resources/assets/js/settings/team/membership.js
@@ -32,7 +32,7 @@ Vue.component('spark-team-settings-membership-screen', {
          * Determine if all necessary data has been loaded.
          */
         everythingIsLoaded: function () {
-            return this.user && this.team;
+            return this.user && this.team && this.roles.length > 0;
         },
 
 


### PR DESCRIPTION
everythingIsLoaded has to depend on the roles array being filled, otherwise there are occasions where roles aren't loaded before the page displays. This results in a blank membership page because the role filter throws an error.