### PR TITLE
Error while creating a team using PostgresSQL

### DIFF
--- a/app/Repositories/TeamRepository.php
+++ b/app/Repositories/TeamRepository.php
@@ -16,13 +16,15 @@ class TeamRepository implements Contract
      */
     public function create($user, array $data)
     {
-        $team = $user->teams()->create(
-            ['name' => $data['name']], ['role' => 'owner']
-        );
+        $teamClass = Spark::model('teams', Team::class);
 
+        $team = new $teamClass(['name' => $data['name']]);
         $team->owner_id = $user->id;
-
         $team->save();
+
+        $team = $user->teams()->attach(
+            $team, ['role' => 'owner']
+        );
 
         return $team;
     }


### PR DESCRIPTION
Hello,

While trying to create a team using PostgresSql, I get an error :

```
SQLSTATE[23502]: Not null violation: 7 ERROR: null value in column "owner_id" violates not-null constraint
DETAIL: Failing row contains (13, null, Test, 2015-10-08 14:54:28, 2015-10-08 14:54:28). (SQL: insert into "teams" ("name", "updated_at", "created_at") values (Test, 2015-10-08 14:54:28, 2015-10-08 14:54:28) returning "id")
```

PostgresSQL is strongly enforcing schema rules, so it fails when trying to create a new team without specifying the owner_id  as below : 

```
public function create($user, array $data)
    {
        $team = $user->teams()->create(
            ['name' => $data['name']], ['role' => 'owner']
        );

        $team->owner_id = $user->id;

        $team->save();

        return $team;
    }
```

As the owner_id is not fillable on the Team model, I had to manually attach the Team instance with the right owner_id to solve it