### PR TITLE
Addition of a feature to manipulate with the spark routes from laravel application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .php_cs.cache
 /node_modules
 /vendor
+/.idea

--- a/app/Http/spark-routes.php
+++ b/app/Http/spark-routes.php
@@ -1,5 +1,13 @@
 <?php
 
+Route::get('/', function () {
+    return view('spark::welcome');
+});
+
+Route::get('home', ['middleware' => 'auth', function () {
+    return view('home');
+}]);
+
 // Terms Routes...
 $router->get('terms', 'TermsController@show');
 

--- a/app/Http/spark-routes.php
+++ b/app/Http/spark-routes.php
@@ -1,10 +1,12 @@
 <?php
 
-Route::get('/', function () {
+/** @var $router \Illuminate\Routing\Router */
+
+$router->get('/', function () {
     return view('spark::welcome');
 });
 
-Route::get('home', ['middleware' => 'auth', function () {
+$router->get('home', ['middleware' => 'auth', function () {
     return view('home');
 }]);
 

--- a/app/Providers/SparkServiceProvider.php
+++ b/app/Providers/SparkServiceProvider.php
@@ -41,9 +41,12 @@ class SparkServiceProvider extends ServiceProvider
         if (! $this->app->routesAreCached()) {
             $router = app('router');
 
-            $router->group(['namespace' => 'Laravel\Spark\Http\Controllers'], function ($router) {
-                require __DIR__.'/../Http/routes.php';
-            });
+            if (is_file($routesFile = config('spark.routes'))) {
+                $router->group(['namespace' => config('spark.controllersNamespace')], function ($router) use ($routesFile)
+                {
+                    require $routesFile;
+                });
+            }
         }
     }
 
@@ -59,6 +62,8 @@ class SparkServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 SPARK_PATH.'/resources/views' => base_path('resources/views/vendor/spark'),
+                SPARK_PATH.'/config' => base_path('config'),
+
             ], 'spark-full');
 
             $this->publishes([
@@ -75,6 +80,7 @@ class SparkServiceProvider extends ServiceProvider
                 SPARK_PATH.'/resources/views/auth/registration/simple/basics.blade.php' => base_path('resources/views/vendor/spark/auth/registration/simple/basics.blade.php'),
                 SPARK_PATH.'/resources/views/auth/registration/subscription/basics.blade.php' => base_path('resources/views/vendor/spark/auth/registration/subscription/basics.blade.php'),
                 SPARK_PATH.'/resources/views/settings/team/tabs/membership/modals/edit-team-member.blade.php' => base_path('resources/views/vendor/spark/settings/team/tabs/membership/modals/edit-team-member.blade.php'),
+                SPARK_PATH.'/config/spark.php' => base_path('config/spark.php'),
             ], 'spark-basics');
         }
     }

--- a/config/spark.php
+++ b/config/spark.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+
+    /*
+     * Spark routes file
+     */
+    'routes' => app_path('Http/spark-routes.php'),
+
+    /*
+     * Routes controllers namespace
+     */
+    'controllersNamespace'   => 'Laravel\Spark\Http\Controllers',
+];

--- a/resources/stubs/app/Http/routes.php
+++ b/resources/stubs/app/Http/routes.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
 |--------------------------------------------------------------------------
 | Application Routes
@@ -11,10 +10,5 @@
 |
 */
 
-Route::get('/', function () {
-	return view('spark::welcome');
-});
-
-Route::get('home', ['middleware' => 'auth', function () {
-	return view('home');
-}]);
+/** @var $router \Illuminate\Routing\Router */
+/** @var $this \App\Providers\RouteServiceProvider */

--- a/resources/stubs/app/Http/routes.php
+++ b/resources/stubs/app/Http/routes.php
@@ -11,4 +11,3 @@
 */
 
 /** @var $router \Illuminate\Routing\Router */
-/** @var $this \App\Providers\RouteServiceProvider */

--- a/resources/stubs/app/Http/spark-routes.php
+++ b/resources/stubs/app/Http/spark-routes.php
@@ -1,0 +1,98 @@
+<?php
+
+Route::get('/', function () {
+    return view('spark::welcome');
+});
+
+Route::get('home', ['middleware' => 'auth', function () {
+    return view('home');
+}]);
+
+
+// Terms Routes...
+$router->get('terms', 'TermsController@show');
+
+// Settings Dashboard Routes...
+$router->get('settings', 'Settings\DashboardController@show');
+
+// Profile Routes...
+$router->put('settings/user', 'Settings\ProfileController@updateUserProfile');
+
+// Team Routes...
+if (Spark::usingTeams()) {
+    $router->post('settings/teams', 'Settings\TeamController@store');
+    $router->get('settings/teams/{id}', 'Settings\TeamController@edit');
+    $router->put('settings/teams/{id}', 'Settings\TeamController@update');
+    $router->delete('settings/teams/{id}', 'Settings\TeamController@destroy');
+    $router->get('settings/teams/switch/{id}', 'Settings\TeamController@switchCurrentTeam');
+
+    $router->post('settings/teams/{id}/invitations', 'Settings\InvitationController@sendTeamInvitation');
+    $router->post('settings/teams/invitations/{invite}/accept', 'Settings\InvitationController@acceptTeamInvitation');
+    $router->delete('settings/teams/invitations/{invite}', 'Settings\InvitationController@destroyTeamInvitationForUser');
+    $router->delete('settings/teams/{team}/invitations/{invite}', 'Settings\InvitationController@destroyTeamInvitationForOwner');
+
+    $router->put('settings/teams/{team}/members/{user}', 'Settings\TeamController@updateTeamMember');
+    $router->delete('settings/teams/{team}/members/{user}', 'Settings\TeamController@removeTeamMember');
+    $router->delete('settings/teams/{team}/membership', 'Settings\TeamController@leaveTeam');
+}
+
+// Security Routes...
+$router->put('settings/user/password', 'Settings\SecurityController@updatePassword');
+$router->post('settings/user/two-factor', 'Settings\SecurityController@enableTwoFactorAuth');
+$router->delete('settings/user/two-factor', 'Settings\SecurityController@disableTwoFactorAuth');
+
+// Subscription Routes...
+if (count(Spark::plans()) > 0) {
+    $router->post('settings/user/plan', 'Settings\SubscriptionController@subscribe');
+    $router->put('settings/user/plan', 'Settings\SubscriptionController@changeSubscriptionPlan');
+    $router->delete('settings/user/plan', 'Settings\SubscriptionController@cancelSubscription');
+    $router->post('settings/user/plan/resume', 'Settings\SubscriptionController@resumeSubscription');
+    $router->put('settings/user/card', 'Settings\SubscriptionController@updateCard');
+    $router->put('settings/user/vat', 'Settings\SubscriptionController@updateExtraBillingInfo');
+    $router->get('settings/user/plan/invoice/{id}', 'Settings\SubscriptionController@downloadInvoice');
+}
+
+// Authentication Routes...
+$router->get('login', 'Auth\AuthController@getLogin');
+$router->post('login', 'Auth\AuthController@postLogin');
+$router->get('logout', 'Auth\AuthController@getLogout');
+
+// Two-Factor Authentication Routes...
+if (Spark::supportsTwoFactorAuth()) {
+    $router->get('login/token', 'Auth\AuthController@getToken');
+    $router->post('login/token', 'Auth\AuthController@postToken');
+}
+
+// Registration Routes...
+$router->get('register', 'Auth\AuthController@getRegister');
+$router->post('register', 'Auth\AuthController@postRegister');
+
+// Password Routes...
+$router->get('password/email', 'Auth\PasswordController@getEmail');
+$router->post('password/email', 'Auth\PasswordController@postEmail');
+$router->get('password/reset/{token}', 'Auth\PasswordController@getReset');
+$router->post('password/reset', 'Auth\PasswordController@postReset');
+
+// User API Routes...
+$router->get('spark/api/users/me', 'API\UserController@getCurrentUser');
+
+// Team API Routes...
+if (Spark::usingTeams()) {
+    $router->get('spark/api/teams/invitations', 'API\InvitationController@getPendingInvitationsForUser');
+    $router->get('spark/api/teams/roles', 'API\TeamController@getTeamRoles');
+    $router->get('spark/api/teams/{id}', 'API\TeamController@getTeam');
+    $router->get('spark/api/teams', 'API\TeamController@getAllTeamsForUser');
+    $router->get('spark/api/teams/invitation/{code}', 'API\InvitationController@getInvitation');
+}
+
+// Subscription API Routes...
+if (count(Spark::plans()) > 0) {
+    $router->get('spark/api/subscriptions/plans', 'API\SubscriptionController@getPlans');
+    $router->get('spark/api/subscriptions/coupon/{code}', 'API\SubscriptionController@getCoupon');
+    $router->get('spark/api/subscriptions/user/coupon', 'API\SubscriptionController@getCouponForUser');
+}
+
+// Stripe Routes...
+if (count(Spark::plans()) > 0) {
+    $router->post('stripe/webhook', 'Stripe\WebhookController@handleWebhook');
+}

--- a/resources/stubs/app/Http/spark-routes.php
+++ b/resources/stubs/app/Http/spark-routes.php
@@ -1,10 +1,12 @@
 <?php
 
-Route::get('/', function () {
+/** @var $router \Illuminate\Routing\Router */
+
+$router->get('/', function () {
     return view('spark::welcome');
 });
 
-Route::get('home', ['middleware' => 'auth', function () {
+$router->get('home', ['middleware' => 'auth', function () {
     return view('home');
 }]);
 


### PR DESCRIPTION
Sometimes we need to manipulate with the spak routes.
For example I want to apply it to the specific subdomain or want to set route name for them, or I want to set other (extended) controller to the spark route, or etc.
I can redefine it after spark routes applies, but I think, it's not very clear.

With this feature we have file `app/Http/spark-routes.php` with the spark routes after installation.

And after execution `php artisan vendor:publish --tag=spark-full` or `php artisan vendor:publish --tag=spark-basics` we have `config/spark.php`.
With this config we can manipulate with loading the spark routes file and base controllers namespace for it.

