### PR TITLE
fix import path

### DIFF
--- a/resources/stubs/resources/assets/sass/app.scss
+++ b/resources/stubs/resources/assets/sass/app.scss
@@ -16,4 +16,4 @@ $navbar-height: 65px;
 /*
  * Spark Styling...
  */
-@import "spark/resources/assets/sass/spark";
+@import "vendor/laravel/spark/resources/assets/sass/spark";


### PR DESCRIPTION
gulp sass pre-compilation breaks because these files are not copied to the application during install.