### PR TITLE
Fix for overlapping footer on content

### DIFF
--- a/resources/assets/sass/spark.scss
+++ b/resources/assets/sass/spark.scss
@@ -38,7 +38,7 @@ body {
 	border-top: 1px solid #e7e7e7;
 	bottom: 0;
 	min-height: 80px;
-	position: absolute;
+	position: fixed;
 	width: 100%;
 
 	.footer-social-icons {


### PR DESCRIPTION
This is a small CSS fix for the `.footer` class. I changed it's position value from `absolute` to `fixed`, because it's causing a layout issue on bigger content. If the content is higher than the screen, when scrolling, the footer gets stuck at the top, and not as it should, on the bottom of the page. Here is a screenshot of the issue:

<img width="980" alt="screen shot 2015-11-02 at 5 49 37 pm" src="https://cloud.githubusercontent.com/assets/4696113/10888011/227e70c4-818a-11e5-8a4c-1361248fb0ed.png">
