### PR TITLE
Add ownedTeams method to CanJoinTeams trait

### DIFF
--- a/app/Teams/CanJoinTeams.php
+++ b/app/Teams/CanJoinTeams.php
@@ -28,6 +28,14 @@ trait CanJoinTeams
     }
 
     /**
+     * Get all of the teams that the user owns.
+     */
+    public function ownedTeams()
+    {
+        return $this->teams()->where("owner_id", $this->getKey());
+    }
+
+    /**
      * Join the team with the given ID.
      *
      * @param  int  $teamId


### PR DESCRIPTION
This method could be useful if you want to restrict certain methods to the team owner.