### PR TITLE
spark/api/... routes now in 'web' middleware group.

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -64,9 +64,7 @@ Route::group(['middleware' => ['web']], function ($router) {
     $router->post('password/email', 'Auth\PasswordController@postEmail');
     $router->get('password/reset/{token}', 'Auth\PasswordController@getReset');
     $router->post('password/reset', 'Auth\PasswordController@postReset');
-});
 
-Route::group(['middleware' => ['api']], function ($router) {
     // User API Routes...
     $router->get('spark/api/users/me', 'API\UserController@getCurrentUser');
 
@@ -85,6 +83,10 @@ Route::group(['middleware' => ['api']], function ($router) {
         $router->get('spark/api/subscriptions/coupon/{code}', 'API\SubscriptionController@getCoupon');
         $router->get('spark/api/subscriptions/user/coupon', 'API\SubscriptionController@getCouponForUser');
     }
+
+});
+
+Route::group(['middleware' => ['api']], function ($router) {
 
     // Stripe Routes...
     if (count(Spark::plans()) > 0) {


### PR DESCRIPTION
Not sure how I missed these on [the initial change](https://github.com/laravel/spark/pull/164). But after #167 and further investigation [almost](https://github.com/laravel/spark/blob/master/app/Http/Controllers/API/TeamController.php#L31) [all](https://github.com/laravel/spark/blob/master/app/Http/Controllers/API/SubscriptionController.php#L24) `spark/api/...` routes rely on the `auth` middleware which relies on Session store. 

Building up from the base 'api' middleware group, this is the minimum to make these routes work:

```
'api' => [
    \App\Http\Middleware\EncryptCookies::class,
    \Illuminate\Session\Middleware\StartSession::class,
    \App\Http\Middleware\VerifyCsrfToken::class,
    'throttle:60,1',
],
```

Without those $this->auth->guest() returns false or throws an error.

Possible approaches to a long term solution:

1. Since these routes are required to work for the 'web' view, they should be in the 'web' middleware group, and assume any potential overhead of unused middlewares. (what this PR accomplishes)
2. To optimize the middleware stack for Web api calls (ajax), create an 'ajax' middleware group, potentially in Laravel core, that only includes session/form related middlewares.

Fixes #167.