### PR TITLE
Two factor alert link now has 'alert-link' class

### DIFF
--- a/resources/views/settings/tabs/security/two-factor.blade.php
+++ b/resources/views/settings/tabs/security/two-factor.blade.php
@@ -8,7 +8,7 @@
 				<div class="panel-body">
 					<div class="alert alert-info">
 						To use two factor authentication, you <strong>must</strong> install the
-						<a href="https://authy.com" target="_blank">Authy</a> application on your phone.
+						<a href="https://authy.com" class="alert-link" target="_blank">Authy</a> application on your phone.
 					</div>
 
             		<spark-error-alert :form="forms.enableTwoFactorAuth"></spark-error-alert>


### PR DESCRIPTION
On the `/settings` page, the Authy link is basically invisible:

![authy-invisible](https://cloud.githubusercontent.com/assets/37359/12051298/911e2354-aecf-11e5-80f0-50016c09b66a.png)

Per [Bootstrap's alert component](http://getbootstrap.com/components/#alerts-links), links should have `alert-link` class.

Result:

![alert-result](https://cloud.githubusercontent.com/assets/37359/12051360/9e10775a-aed0-11e5-9179-d6270c227ac1.png)
