### PR TITLE
Fix Vue error when changing selected plan

### DIFF
--- a/resources/views/auth/registration/subscription/billing.blade.php
+++ b/resources/views/auth/registration/subscription/billing.blade.php
@@ -82,7 +82,7 @@
 						<span v-else>
 							<i class="fa fa-btn fa-check-circle"></i>
 
-							<span v-if=" ! selectedPlan.trialDays">
+							<span v-if="! selectedPlan || ! selectedPlan.trialDays">
 								Register
 							</span>
 


### PR DESCRIPTION
After selecting a plan, then clicking "Change Plan", the selected plan is set to null, which causes Vue to console log:

`[Vue warn]: Error when evaluating expression "selectedPlan.trialDays". Turn on debug mode to see stack trace.`

This fixes that.