### PR TITLE
Fix password reset email template for Laravel 5.2

### DIFF
--- a/app/Console/Install.php
+++ b/app/Console/Install.php
@@ -214,7 +214,7 @@ class Install extends Command
         $path = config_path('auth.php');
 
         file_put_contents($path, str_replace(
-            'emails.password', 'spark::emails.auth.password.email', file_get_contents($path)
+            'auth.emails.password', 'spark::emails.auth.password.email', file_get_contents($path)
         ));
     }
 


### PR DESCRIPTION
Altered the search+replace in updateAuthConfig() to reflect new default ("auth.emails.password") in an out-of-the-box Laravel 5.2 install, as per laravel/spark#181