### PR TITLE
fix PR 194 - bump laravel elixir version

### DIFF
--- a/resources/stubs/package.json
+++ b/resources/stubs/package.json
@@ -4,8 +4,8 @@
     "gulp": "^3.8.8"
   },
   "dependencies": {
-    "bootstrap-sass": "^4.0.0",
-    "laravel-elixir": "^3.0.0",
+    "bootstrap-sass": "^3.0.0",
+    "laravel-elixir": "^4.0.0",
     "laravel-spark": "^1.0.0"
   }
 }


### PR DESCRIPTION
reverts #194 which bumped bootstrap instead of Laravel Elixir which [has a v4.0 release](https://github.com/laravel/elixir/releases) while bootstrap does not.